### PR TITLE
Rename the go module to github.com/ocp-power-automation/rsct-operator

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -5,7 +5,7 @@ plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}
 projectName: rsct-operator
-repo: github.com/mjturek/rsct-operator
+repo: github.com/ocp-power-automation/rsct-operator
 resources:
 - api:
     crdVersion: v1
@@ -14,6 +14,6 @@ resources:
   domain: ibm.com
   group: rsct
   kind: RSCT
-  path: github.com/mjturek/rsct-operator/api/v1alpha1
+  path: github.com/ocp-power-automation/rsct-operator/api/v1alpha1
   version: v1alpha1
 version: "3"

--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	rsctv1alpha1 "github.com/mjturek/rsct-operator/api/v1alpha1"
+	rsctv1alpha1 "github.com/ocp-power-automation/rsct-operator/api/v1alpha1"
 )
 
 type RSCTConfig struct {

--- a/controllers/daemonset.go
+++ b/controllers/daemonset.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	rsctv1alpha1 "github.com/mjturek/rsct-operator/api/v1alpha1"
+	rsctv1alpha1 "github.com/ocp-power-automation/rsct-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/controllers/service_account.go
+++ b/controllers/service_account.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	operatorv1alpha1 "github.com/mjturek/rsct-operator/api/v1alpha1"
+	operatorv1alpha1 "github.com/ocp-power-automation/rsct-operator/api/v1alpha1"
 )
 
 // ensureRSCTServiceAccount ensures that the RSCT service account exists.

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -2,7 +2,7 @@ package controllers
 
 import (
 	"context"
-	rsctv1alpha1 "github.com/mjturek/rsct-operator/api/v1alpha1"
+	rsctv1alpha1 "github.com/ocp-power-automation/rsct-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 )
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -30,7 +30,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	rsctv1alpha1 "github.com/mjturek/rsct-operator/api/v1alpha1"
+	rsctv1alpha1 "github.com/ocp-power-automation/rsct-operator/api/v1alpha1"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mjturek/rsct-operator
+module github.com/ocp-power-automation/rsct-operator
 
 go 1.17
 

--- a/main.go
+++ b/main.go
@@ -31,8 +31,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	rsctv1alpha1 "github.com/mjturek/rsct-operator/api/v1alpha1"
-	"github.com/mjturek/rsct-operator/controllers"
+	rsctv1alpha1 "github.com/ocp-power-automation/rsct-operator/api/v1alpha1"
+	"github.com/ocp-power-automation/rsct-operator/controllers"
 	//+kubebuilder:scaffold:imports
 )
 


### PR DESCRIPTION
Fix for the issue: [Rename the go module to github.com/ocp-power-automation/rsct-operator](https://github.com/ocp-power-automation/rsct-operator/issues/5)

Fixes: #5 