### PR TITLE
Supporting OwnNamespace and SingleNamespace install modes

### DIFF
--- a/bundle/manifests/rsct-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rsct-operator.clusterserviceversion.yaml
@@ -239,13 +239,13 @@ spec:
         serviceAccountName: rsct-operator-controller-manager
     strategy: deployment
   installModes:
-  - supported: false
+  - supported: true
     type: OwnNamespace
-  - supported: false
+  - supported: true
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: true
+  - supported: false
     type: AllNamespaces
   keywords:
   - rsct

--- a/config/manifests/bases/rsct-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/rsct-operator.clusterserviceversion.yaml
@@ -25,13 +25,13 @@ spec:
       deployments: null
     strategy: ""
   installModes:
-  - supported: false
+  - supported: true
     type: OwnNamespace
-  - supported: false
+  - supported: true
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: true
+  - supported: false
     type: AllNamespaces
   keywords:
   - rsct


### PR DESCRIPTION
Adding the Install Modes `OwnNamespace` and `SingleNamespace` in the CSV to support the namespace targeted by Operator group.