### PR TITLE
Enhancement for catalog-build to use ppc64le opm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,10 @@ endif
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
 OPERATOR_SDK_VERSION ?= v1.34.1
 
+# Set the OPM version to use. By default, what is installed on the system is used.
+# This is useful for building catalog image
+OPM_VERSION ?= v1.43.0
+
 # Image URL to use all building/pushing image targets
 IMG ?= $(IMAGE_TAG_BASE):$(VERSION)
 
@@ -275,7 +279,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.43.0/$${OS}-$${ARCH}-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/$(OPM_VERSION)/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else
@@ -300,7 +304,7 @@ endif
 # https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
 .PHONY: catalog-build
 catalog-build: opm ## Build a catalog image.
-	$(OPM) index add --container-tool $(CONTAINER_TOOL) --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
+	$(OPM) index add --container-tool $(CONTAINER_TOOL) --mode semver --tag $(CATALOG_IMG) -i quay.io/operator-framework/opm:$(OPM_VERSION)-ppc64le --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
 
 # Push the catalog image.
 .PHONY: catalog-push


### PR DESCRIPTION
**Problem:** 
Catalog source pod fails with `exec /bin/opm: exec format error` if operator index container images built using the default OPM image (latest tag) on non ppc64le platform.

**Solution:**
Specify OPM image `quay.io/operator-framework/opm:$(OPM_VERSION)-ppc64le`, while adding operator bundles to an index.

