### PR TITLE
Upgrading container base image and go lang builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 AS builder
+FROM golang:1.22.4 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -23,7 +23,7 @@ COPY internal/controller/ internal/controller/
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
-FROM ubi8:8.7-929
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 WORKDIR /
 RUN mkdir /licenses
 COPY LICENSE /licenses


### PR DESCRIPTION
This PR upgrades the RSCT Operator's container base image and fixes the 111 vulnerabilities detected by Quay Security Scanner