### PR TITLE
Add GitHub workflow to build operator images

### DIFF
--- a/.github/workflows/build-operator-images.yml
+++ b/.github/workflows/build-operator-images.yml
@@ -1,0 +1,62 @@
+name: Build and Publish RSCT Operator
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+env:
+  GO_VERSION: "1.22"
+  IMAGE_TAG_BASE: ghcr.io/${{ github.repository }}
+  IMAGE_BUILDER: "docker"
+  
+jobs:
+  build-and-publish-operator:
+    name: Build and Publish RSCT Operator Images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set the release version
+        run: echo "VERSION=$(echo ${GITHUB_REF/refs\/tags\//})" >> $GITHUB_ENV
+
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Set up Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          check-latest: true
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build operator container images and push
+        id: docker_build
+        uses: docker/build-push-action@v5
+        with:
+          file: Dockerfile
+          tags: ${{ env.IMAGE_TAG_BASE }}:${{ env.VERSION }}, ${{ env.IMAGE_TAG_BASE }}:latest
+          push: true
+          platforms: 'linux/ppc64le'
+          provenance: false
+
+      - name: Build operator bundle and push
+        id: operator_bundle
+        run: |
+          make bundle bundle-build bundle-push
+
+      - name: Building a catalog containing a bundled Operator
+        id: catalog_build
+        run: |
+          make catalog-build catalog-push

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22.4 AS builder
+FROM golang:1.22 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
Adding a GitHub workflow for publishing the operator images.

It requires the `GITHUB_TOKEN` secret to push the images to ghcr.io.