### PR TITLE
Add all the valid semantic version tags

### DIFF
--- a/.github/workflows/build-operator-images.yml
+++ b/.github/workflows/build-operator-images.yml
@@ -3,7 +3,7 @@ name: Build and Publish RSCT Operator
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+      - 'v*.*.*'
 
 env:
   GO_VERSION: "1.22"
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set the release version
-        run: echo "VERSION=$(echo ${GITHUB_REF/refs\/tags\//})" >> $GITHUB_ENV
+        run: echo "VERSION=$(echo ${GITHUB_REF/refs\/tags\/v/})" >> $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Here is the valid description for the tags per the GitHub release process

**Tagging suggestions**
```
It’s common practice to prefix your version names with the letter v. Some good tag names might be v1.0.0 or v2.3.4.

If the tag isn’t meant for production use, add a pre-release version after the version name. Some good pre-release versions might be v0.2.0-alpha or v5.9-beta.3.
```

The current code doesn't deal with the above scenario, hence this PR will address this issue.