### PR TITLE
Defining the minKubeVersion as 1.25.0

### DIFF
--- a/bundle/manifests/rsct-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rsct-operator.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-06-04T09:24:45Z"
+    createdAt: "2024-07-10T12:35:54Z"
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: rsct-operator.v0.0.1
@@ -260,6 +260,7 @@ spec:
   - email: mjturek@us.ibm.com
     name: Michael Turek
   maturity: alpha
+  minKubeVersion: 1.25.0
   provider:
     name: IBM
   version: 0.0.1

--- a/config/manifests/bases/rsct-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/rsct-operator.clusterserviceversion.yaml
@@ -46,6 +46,7 @@ spec:
   - email: mjturek@us.ibm.com
     name: Michael Turek
   maturity: alpha
+  minKubeVersion: 1.25.0
   provider:
     name: IBM
   version: 0.0.0


### PR DESCRIPTION
This PR address this issue - https://github.com/ocp-power-automation/rsct-operator/issues/26.

Specifying minimum compatible Kubernetes version to 1.25.0 (OCP 4.12)