### PR TITLE
Renaming powervm-rmc to rsct

### DIFF
--- a/internal/controller/daemonset.go
+++ b/internal/controller/daemonset.go
@@ -36,7 +36,7 @@ const (
 	masterNodeRoleLabel = "node-role.kubernetes.io/master"
 	osID                = "rhcos"
 	rmcPort             = 657
-	rmcAppName          = "powervm-rmc"
+	rmcAppName          = "rsct"
 )
 
 type DaemonSetConfig struct {
@@ -103,7 +103,7 @@ func (r *RSCTReconciler) currentRSCTDaemonSet(ctx context.Context) (bool, *appsv
 // desiredRSCTDaemonSet returns the desired daemon set resource.
 func desiredRSCTDaemonSet(config *DaemonSetConfig) (*appsv1.DaemonSet, error) {
 	matchLabels := map[string]string{
-		"app": "powervm-rmc",
+		"app": "rsct",
 	}
 
 	nodeSelectorLabels := map[string]string{

--- a/internal/controller/rsct_controller.go
+++ b/internal/controller/rsct_controller.go
@@ -80,14 +80,14 @@ func (r *RSCTReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 	haveServiceAccount, sa, err := r.ensureRSCTServiceAccount(ctx, rsct)
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to ensure powervm-rmc service account: %w", err)
+		return reconcile.Result{}, fmt.Errorf("failed to ensure rsct service account: %w", err)
 	} else if !haveServiceAccount {
-		return reconcile.Result{}, fmt.Errorf("failed to get powervm-rmc service account: %w", err)
+		return reconcile.Result{}, fmt.Errorf("failed to get rsct service account: %w", err)
 	}
 
 	_, currentDaemonSet, err := r.ensureRSCTDaemonSet(ctx, sa, rsct)
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to ensure powervm-rmc daemonSet: %w", err)
+		return reconcile.Result{}, fmt.Errorf("failed to ensure rsct daemonSet: %w", err)
 	}
 	if err := r.updateRSCTStatus(ctx, rsct, currentDaemonSet); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to update RSCT custom resource %s: %w", rsct.Name, err)


### PR DESCRIPTION
This PR renames occurrences of `powervm-rmc` to `rsct` in error messages and the app name.