### PR TITLE
Adding spec field for rsct sample custom resource

### DIFF
--- a/config/samples/rsct_v1alpha1_rsct.yaml
+++ b/config/samples/rsct_v1alpha1_rsct.yaml
@@ -23,4 +23,5 @@ metadata:
     app.kubernetes.io/created-by: rsct-operator
   name: rsct
   namespace: rsct-operator-system
+spec: {}
 


### PR DESCRIPTION
Latest rsct-operator image requires `spec` filed in custom resource