### PR TITLE
Switch operator image registry from quay.io to ghcr.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # This variable is used to construct full image tags for bundle and catalog images.
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
-IMAGE_TAG_BASE ?= quay.io/powercloud/rsct-operator
+IMAGE_TAG_BASE ?= ghcr.io/ocp-power-automation/rsct-operator
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)

--- a/bundle/manifests/rsct-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rsct-operator.clusterserviceversion.yaml
@@ -173,7 +173,7 @@ spec:
                 - --leader-elect
                 command:
                 - /manager
-                image: quay.io/powercloud/rsct-operator:0.0.1
+                image: ghcr.io/ocp-power-automation/rsct-operator:latest
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/powercloud/rsct-operator
-  newTag: 0.0.1
+  newName: ghcr.io/ocp-power-automation/rsct-operator
+  newTag: latest


### PR DESCRIPTION
Switching from quay.io to ghcr.io because the latest operator images are now being pushed to ghcr.io.