### PR TITLE
Set the AllNamespaces installation mode to true

### DIFF
--- a/config/manifests/bases/rsct-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/rsct-operator.clusterserviceversion.yaml
@@ -48,7 +48,7 @@ spec:
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
   keywords:
   - rsct


### PR DESCRIPTION
Fixes: https://github.com/ocp-power-automation/rsct-operator/issues/104
Setting `AllNamespaces` to true because of OLM v1 limitation:
- must support installation via the `AllNamespaces` install mode` - [olmv1_limitations](https://operator-framework.github.io/operator-controller/project/olmv1_limitations/)


