### PR TITLE
Adding a new variable PREVIOUS_IMAGE_TAG_BASE in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
 IMAGE_TAG_BASE ?= ghcr.io/ocp-power-automation/rsct-operator
+PREVIOUS_IMAGE_TAG_BASE ?= ghcr.io/ocp-power-automation/rsct-operator
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
@@ -292,7 +293,7 @@ BUNDLE_IMGS ?= $(BUNDLE_IMG)
 # The image tag given to the resulting catalog image (e.g. make catalog-build CATALOG_IMG=example.com/operator-catalog:v0.2.0).
 CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:v$(VERSION)
 CATALOG_IMG_LATEST ?= $(IMAGE_TAG_BASE)-catalog:latest
-CATALOG_PREVIOUS_IMG ?= $(IMAGE_TAG_BASE)-catalog:v$(PREVIOUS_VERSION)
+CATALOG_PREVIOUS_IMG ?= $(PREVIOUS_IMAGE_TAG_BASE)-catalog:v$(PREVIOUS_VERSION)
 
 # Set CATALOG_BASE_IMG to an existing catalog image tag to add $BUNDLE_IMGS to that image.
 ifneq ($(origin CATALOG_BASE_IMG), undefined)


### PR DESCRIPTION
This variable will be used to preserve and use the previous operator versions from `ghcr.io/ocp-power-automation/rsct-operator` while building the images locally with different registry.