### PR TITLE
fix: use fixed container name

### DIFF
--- a/internal/controller/daemonset.go
+++ b/internal/controller/daemonset.go
@@ -147,7 +147,7 @@ func desiredRSCTDaemonSet(config *DaemonSetConfig) (*appsv1.DaemonSet, error) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:  config.Name,
+							Name:  rmcAppName,
 							Image: config.Image,
 							LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{

--- a/internal/controller/daemonset_test.go
+++ b/internal/controller/daemonset_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func serviceAccount(name, namespace string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
+// TestDesiredRSCTDaemonSet_ContainerNameIsAlwaysRmcAppName verifies that the
+// container name is always hardcoded to rmcAppName regardless of the CR name
+// passed via DaemonSetConfig.Name.
+func TestDesiredRSCTDaemonSet_ContainerNameIsAlwaysRmcAppName(t *testing.T) {
+	crNames := []string{
+		"rsct",
+		"my-rsct",
+		"rsct-3.3.3.6-ubi9-test",
+		"rsct.with.dots",
+		"x",
+	}
+
+	for _, crName := range crNames {
+		t.Run(crName, func(t *testing.T) {
+			config := &DaemonSetConfig{
+				Namespace:      "default",
+				Name:           crName,
+				Image:          "example.com/rsct:latest",
+				MemoryLimit:    "1Gi",
+				MemoryRequest:  "500Mi",
+				CPURequest:     "0.1",
+				ServiceAccount: serviceAccount(crName, "default"),
+			}
+
+			ds, err := desiredRSCTDaemonSet(config)
+			if err != nil {
+				t.Fatalf("desiredRSCTDaemonSet(%q) returned unexpected error: %v", crName, err)
+			}
+
+			containers := ds.Spec.Template.Spec.Containers
+			if len(containers) != 1 {
+				t.Fatalf("expected 1 container, got %d", len(containers))
+			}
+
+			if got := containers[0].Name; got != rmcAppName {
+				t.Errorf("container name = %q, want %q (rmcAppName); CR name was %q",
+					got, rmcAppName, crName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #201 

Problem: RSCT instances could be created with names containing dots (e.g.`rsct-3.3.3.6-ubi9-test`). 

The controller then used the CR name verbatim as the DaemonSet container name, which Kubernetes rejects — container names must be valid DNS labels (no dots). This left the operator in a permanent error-retry loop with no user-facing rejection at creation time.

Fix: 
-Added DNS label validation in `ValidateCreate` (regex based)
-Container `name` field in `desiredRSCTDaemonSet` now uses the constant `rmcAppName` (`"rsct"`) instead of `config.Name`. The container name is an implementation detail and should not be derived from the CR name.